### PR TITLE
isort your imports, so you don't have to.

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
       - run: black --check . || true
       - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --profile black . || true
+      - run: isort --profile black .
       - run: pip install -r requirements.txt || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true

--- a/Main.py
+++ b/Main.py
@@ -1,9 +1,9 @@
-from scene import *
-import sound
-import random
 import math
-import ui
+import random
 
+import sound
+import ui
+from scene import *
 
 A = Action
 


### PR DESCRIPTION
Make `isort` a mandatory test... https://github.com/PyCQA/isort

Standard Library imports first and then Pythonista imports come after.